### PR TITLE
Fix edgecase with bpiCalculator.PGF

### DIFF
--- a/src/components/bpi/index.tsx
+++ b/src/components/bpi/index.tsx
@@ -19,7 +19,7 @@ export default class bpiCalcuator{
   private z:number = 0;
   private traditionalMode = _traditionalMode();
   private powCoef:number = this.traditionalMode === 1 ? 1.5 : this.newcoef;
-  private pgf = (j:number):number=> j === this.m ? this.m * 0.8 : 1 + ( j / this.m - 0.5 ) / ( 1 - j / this.m );
+  private pgf = (j:number):number=> j === this.m ? this.m : 1 + ( j / this.m - 0.5 ) / ( 1 - j / this.m );
 
   private _allTwelvesLength:number = 0;
   private _allTwelvesBPI:number[] = [];


### PR DESCRIPTION
Multiplying max by 0.8 can result in scores losing BPI, Instead, it should be multiplied by 1.

For WR=3488, KAVG=3102, MAX=3488 (GRID KNIGHT [L] MAX)
```
MAX-2 = 90.43BPI
MAX-1 = 104.58BPI (!!!)
MAX+0 = 100BPI
```

*****
**DeepL translation**

最大値に0.8をかけるとBPIが減少するため、1倍にしてください。

WR=3488, KAVG=3102, MAX=3488 (GRID KNIGHT [L] MAX)
```
MAX-2＝90.43bpi
MAX-1＝104.58BPI（！！）。
MAX+0 = 100BPI
```