### PR TITLE
総合BPIの算出ミス修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+public/assets/version.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "unstated": "^2.1.1"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "gh-pages": "^3.2.3",
         "react-app-rewired": "^2.1.8"
       }
@@ -7807,6 +7808,24 @@
       "peerDependencies": {
         "prop-types": "^15.0.0",
         "react": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -25746,6 +25765,15 @@
       "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.1.6.tgz",
       "integrity": "sha512-eCnYYEUEc5i32LHwpE/W7NlddOB9oHwsPaWtWzYtflNkkwa3IfindIcoXdVWs12zCbwaMCavKNu84EXogVIWHw==",
       "requires": {}
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -59,15 +59,16 @@
     "unstated": "^2.1.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "gh-pages": "^3.2.3",
     "react-app-rewired": "^2.1.8"
   },
   "scripts": {
-    "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
-    "test": "react-app-rewired test",
-    "eject": "react-app-rewired eject",
-    "deploy": "npm run build&&gh-pages -d build",
+    "start": "git rev-parse --short HEAD > ./public/assets/version.txt && react-app-rewired start",
+    "build": "react-app-rewired build ",
+    "test": "react-app-rewired test ",
+    "eject": "react-app-rewired eject ",
+    "deploy": "npm run build&&gh-pages -d build ",
     "dpl": "dploy deploy"
   },
   "eslintConfig": {

--- a/src/components/bpi/index.tsx
+++ b/src/components/bpi/index.tsx
@@ -171,10 +171,13 @@ export default class bpiCalculator {
     const playedSongs = this._allTwelvesBPI.length;
     if (playedSongs === 0) return -15;
     let sum = 0, k = Math.log2(this._allTwelvesLength);
-
     for (let i = 0; i < this._allTwelvesLength; ++i) {
       if (i < playedSongs) {
         const bpi = this._allTwelvesBPI[i], m = Math.pow(Math.abs(bpi), k) / this._allTwelvesLength;
+        sum += bpi > 0 ? m : -m;
+      }else{
+        //未プレイ楽曲を-15で埋める
+        const bpi = -15, m = Math.pow(Math.abs(bpi), k) / this._allTwelvesLength;
         sum += bpi > 0 ? m : -m;
       }
     }

--- a/src/components/bpi/index.tsx
+++ b/src/components/bpi/index.tsx
@@ -171,18 +171,21 @@ export default class bpiCalculator {
     const playedSongs = this._allTwelvesBPI.length;
     if (playedSongs === 0) return -15;
     let sum = 0, k = Math.log2(this._allTwelvesLength);
+    if(k === 0) k = 1;
     for (let i = 0; i < this._allTwelvesLength; ++i) {
+      let m = 0;
       if (i < playedSongs) {
-        const bpi = this._allTwelvesBPI[i], m = Math.pow(Math.abs(bpi), k) / this._allTwelvesLength;
+        const bpi = this._allTwelvesBPI[i];
+        m = Math.pow(Math.abs(bpi), k) / this._allTwelvesLength;
         sum += bpi > 0 ? m : -m;
       }else{
         //未プレイ楽曲を-15で埋める
-        const bpi = -15, m = Math.pow(Math.abs(bpi), k) / this._allTwelvesLength;
+        const bpi = -15;
+        m = Math.pow(Math.abs(bpi), k) / this._allTwelvesLength;
         sum += bpi > 0 ? m : -m;
       }
     }
     const res = Math.round(Math.pow(Math.abs(sum), 1 / k) * 100) / 100;
-
     return sum > 0 ? res : -res;
   }
 

--- a/src/components/bpi/index.tsx
+++ b/src/components/bpi/index.tsx
@@ -185,9 +185,7 @@ export default class bpiCalculator {
 
   async setSongs(songs: number[], level: "11" | "12" | null = "12", forceSongLen?: number): Promise<number> {
     this._allTwelvesBPI = songs;
-    console.log(forceSongLen,level);
     this._allTwelvesLength = forceSongLen || await this.songsDB.getSongsNum(level ? level as string : "12");
-    console.log(songs, this._allTwelvesBPI, this._allTwelvesLength, this._allTwelvesBPI.length);
     return this.totalBPI();
   }
 }

--- a/src/components/bpi/index.tsx
+++ b/src/components/bpi/index.tsx
@@ -164,6 +164,10 @@ export default class bpiCalculator {
   set allTwelvesBPI(val: number[]) { this._allTwelvesBPI = val }
 
   totalBPI(): number {
+    /*
+    _allTwelvesBPI: スコア記録済みの☆12楽曲数
+    _allTwelvesLength: WR登録がある全☆12楽曲数
+    */
     const playedSongs = this._allTwelvesBPI.length;
     if (playedSongs === 0) return -15;
     let sum = 0, k = Math.log2(this._allTwelvesLength);
@@ -179,9 +183,11 @@ export default class bpiCalculator {
     return sum > 0 ? res : -res;
   }
 
-  setSongs(songs: number[], sum: number = songs.length): number {
-    this.allTwelvesBPI = songs;
-    this.allTwelvesLength = !Number.isNaN(sum) ? sum : songs.length;
+  async setSongs(songs: number[], level: "11" | "12" | null = "12", forceSongLen?: number): Promise<number> {
+    this._allTwelvesBPI = songs;
+    console.log(forceSongLen,level);
+    this._allTwelvesLength = forceSongLen || await this.songsDB.getSongsNum(level ? level as string : "12");
+    console.log(songs, this._allTwelvesBPI, this._allTwelvesLength, this._allTwelvesBPI.length);
     return this.totalBPI();
   }
 }

--- a/src/components/bpi/totalBPI.tsx
+++ b/src/components/bpi/totalBPI.tsx
@@ -27,12 +27,12 @@ export default class totalBPI {
 
   }
 
-  currentVersion() {
-    return this.bpiCalc.setSongs(this._currentVersion, this._currentVersion.length) || -15;
+  async currentVersion() {
+    return await this.bpiCalc.setSongs(this._currentVersion,String(this.targetLevel) as "11"|"12") || -15;
   }
 
-  lastVersion() {
-    return this.bpiCalc.setSongs(this._lastVersion, this._lastVersion.length) || -15;
+  async lastVersion() {
+    return await this.bpiCalc.setSongs(this._lastVersion,String(this.targetLevel) as "11"|"12") || -15;
   }
 
 

--- a/src/components/bpi/totalBPI.tsx
+++ b/src/components/bpi/totalBPI.tsx
@@ -19,7 +19,7 @@ export default class totalBPI {
     this._currentVersion = (await this.statMain.load()).at();
 
     if (includeLastVersion) {
-      this.statMain.setLastData(String(Number(_currentStore()) - 1))
+      await this.statMain.setLastData(String(Number(_currentStore()) - 1))
       this._lastVersion = this.statMain.at(true);
     }
 

--- a/src/components/firebase/actions.tsx
+++ b/src/components/firebase/actions.tsx
@@ -184,7 +184,7 @@ export default class fbActions {
     const bpi = new bpiCalcuator();
     bpi.setTraditionalMode(0);
     const statsAPI = await new statMain(12).load();
-    const totalBPI = bpi.setSongs(statsAPI.at(), statsAPI.at().length);
+    const totalBPI = await bpi.setSongs(statsAPI.at());
     return totalBPI;
   }
 
@@ -361,7 +361,7 @@ export default class fbActions {
     }
     const qus: any[] = [];
     const q = searchQuery();
-    let total = exactBPI || (await new totalBPI().load()).currentVersion();
+    let total = exactBPI || await (await new totalBPI().load()).currentVersion();
     if(searchBy !== "総合BPI"){
       const radar = await getRadar();
       const target = radar.find((item)=>item.title === searchBy);

--- a/src/components/indexedDB/index.tsx
+++ b/src/components/indexedDB/index.tsx
@@ -850,7 +850,13 @@ export const songsDB = class extends storageWrapper {
   async getSongsNum(level = "12") {
     try {
       return this.getAll(_isSingle()).then(result => {
-        return result.filter((item: songData) => item.difficultyLevel === level && item.wr !== -1).length;
+        return result.filter((item: songData) => {
+          if(_isSingle()){
+            return item.difficultyLevel === level && item.wr !== -1 && !item.removed ;
+          }else{
+            return item.difficultyLevel === level && item.wr !== -1 && !item.removed ;
+          }
+        }).length;
       })
     } catch (e: any) {
       return 1;

--- a/src/components/lists/index.tsx
+++ b/src/components/lists/index.tsx
@@ -20,6 +20,6 @@ export const getListsForNobi = async (targetLevel = 12) => {
   const exec = await new statMain(targetLevel).load();
   const songs = await new scoresDB().getAll();
   const bpi = new bpiCalcuator();
-  const totalBPI = bpi.setSongs(exec.at(), exec.at().length);
+  const totalBPI = await bpi.setSongs(exec.at());
   return songs.filter((item: scoreData) => item.difficultyLevel === String(targetLevel) && (item.currentBPI < Math.pow(totalBPI, 0.9)));
 }

--- a/src/components/stats/main.tsx
+++ b/src/components/stats/main.tsx
@@ -24,7 +24,7 @@ export default class statMain {
 
   private songs: songData[] = [];
 
-  private targetLevel: number = 12;
+  private targetLevel: number;
   private store: string = _currentStore();
   private db = new scoresDB(isSingle, this.store);
 
@@ -315,10 +315,11 @@ export default class statMain {
       return groups;
     }, {});
     const bpi = new bpiCalcuator();
-    Object.keys(distByBPM).map((item: string) => {
-      result[item as BPMDIST] = bpi.setSongs(distByBPM[item as BPMDIST], numDistByBPM[item as BPMDIST]);
-      return 0;
-    });
+    const keys = Object.keys(distByBPM) as BPMDIST[];
+    for (let i = 0; i < keys.length; ++i) {
+      const item = distByBPM[keys[i]];
+      result[keys[i]] = await bpi.setSongs(item,null,item.length);
+    }
     return Object.keys(result).reduce((groups: distBPMI[], item: string) => {
       const name = item as BPMDIST;
       groups.push({

--- a/src/components/stats/main.tsx
+++ b/src/components/stats/main.tsx
@@ -318,6 +318,7 @@ export default class statMain {
     const keys = Object.keys(distByBPM) as BPMDIST[];
     for (let i = 0; i < keys.length; ++i) {
       const item = distByBPM[keys[i]];
+      console.log(await bpi.setSongs(item,null,item.length));
       result[keys[i]] = await bpi.setSongs(item,null,item.length);
     }
     return Object.keys(result).reduce((groups: distBPMI[], item: string) => {

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -940,7 +940,6 @@ text.react-calendar-heatmap-weekday-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: center;
 }
 
 .syncPublicSwitch {

--- a/src/view/components/header/appBar.tsx
+++ b/src/view/components/header/appBar.tsx
@@ -324,7 +324,8 @@ class GlobalHeader extends React.Component<{ global: any, classes: any, theme: a
         ))}
         <Divider />
         <Typography align="center" variant="caption" style={{ margin: "8px 0", width: "100%", display: "block", paddingBottom: "15px" }}>
-          {config.versionString}&nbsp;
+          <Version/>
+          &nbsp;
           {config.lastUpdate}<br />
           <RefLink color="secondary" href="https://twitter.com/BPIManager">@BPIManagerから最新情報を受け取る</RefLink>
           <div style={{ marginTop: 10 }} />
@@ -471,5 +472,26 @@ class InnerList extends React.Component<{
         </Collapse>
       </List>
     );
+  }
+}
+
+class Version extends React.Component<{}, { text: string }>{
+
+  state = {
+    text: ""
+  }
+
+  async componentDidMount() {
+    fetch("/assets/version.txt")
+      .then((response) => response.text())
+      .then((textContent) => {
+        this.setState({ text: textContent.replace(/\s/g,"") });
+      });
+  }
+
+  render() {
+    const { text } = this.state;
+    if (text) return "v-" + text + "-d" + config.versionNumber;
+    return (null);
   }
 }

--- a/src/view/components/songs/played/captured.tsx
+++ b/src/view/components/songs/played/captured.tsx
@@ -101,7 +101,7 @@ class Captured extends React.Component<P, S> {
     }
     const bpi = new bpiCalcuator();
     const statsAPI = await new statMain(12).load();
-    const totalBPI = bpi.setSongs(statsAPI.at(), statsAPI.at().length);
+    const totalBPI = await bpi.setSongs(statsAPI.at());
     const lastDay = await statsAPI.eachDaySum(4, dayjs().subtract(1, 'day').format());
     const lastWeek = await statsAPI.eachDaySum(4, dayjs().subtract(1, 'week').format());
     const rank = bpi.rank(totalBPI, false);

--- a/src/view/components/songs/songRelations.tsx
+++ b/src/view/components/songs/songRelations.tsx
@@ -54,7 +54,7 @@ class SongRelations extends React.Component<P, S> {
     }
 
     let exec = await (await new statMain(12).load()).setLastData(String(Number(_currentStore()) - 1));
-    const totalBPI = new bpiCalculator().setSongs(exec.at(), exec.at().length) || -15;
+    const totalBPI = await new bpiCalculator().setSongs(exec.at()) || -15;
     console.log(totalBPI);
     return this.setState({
       dataset: await this.getSuggest(song),

--- a/src/view/components/songs/songRelations.tsx
+++ b/src/view/components/songs/songRelations.tsx
@@ -12,7 +12,7 @@ import TableContainer from "@mui/material/TableContainer";
 import { scoresDB, songsDB } from "@/components/indexedDB";
 import { _currentStore, _isSingle } from "@/components/settings";
 import bpiCalculator from "@/components/bpi";
-import statMain from "@/components/stats/main";
+import totalBPI from "@/components/bpi/totalBPI";
 import { Alert, AlertTitle } from "@mui/material";
 
 interface P {
@@ -53,13 +53,11 @@ class SongRelations extends React.Component<P, S> {
       return;
     }
 
-    let exec = await (await new statMain(12).load()).setLastData(String(Number(_currentStore()) - 1));
-    const totalBPI = await new bpiCalculator().setSongs(exec.at()) || -15;
-    console.log(totalBPI);
+    const _totalBPI = await (await new totalBPI().load()).currentVersion();
     return this.setState({
       dataset: await this.getSuggest(song),
       isLoading: false,
-      totalBPI: totalBPI
+      totalBPI: _totalBPI
     })
   }
 

--- a/src/view/components/stats/main.tsx
+++ b/src/view/components/stats/main.tsx
@@ -15,6 +15,7 @@ import statMain, { BPITicker } from '@/components/stats/main';
 import { rivalScoreData } from '@/types/data';
 import { ShareOnTwitter } from '../common/shareButtons';
 import { config } from '@/config';
+import _totalBPI from "@/components/bpi/totalBPI";
 import dayjs from 'dayjs';
 
 class Main extends React.Component<{ intl: any, derived?: rivalScoreData[] } & RouteComponentProps, S> {
@@ -48,12 +49,11 @@ class Main extends React.Component<{ intl: any, derived?: rivalScoreData[] } & R
 
   async updateScoreData(targetLevel = 12) {
     const bpi = new bpiCalcuator();
-
+    console.log(targetLevel);
     let exec = await (await new statMain(targetLevel).load(this.props.derived)).setLastData(String(Number(_currentStore()) - 1));
-
-    const totalBPI = bpi.setSongs(exec.at(), exec.at().length) || -15;
-    const lastVerTotalBPI = bpi.setSongs(exec.at(true), exec.at(true).length);
-
+    const t = await new _totalBPI(targetLevel).load(true);
+    const totalBPI = await t.currentVersion();
+    const lastVerTotalBPI = await t.lastVersion();
     //BPI別集計
 
     this.setState({

--- a/src/view/components/stats/main.tsx
+++ b/src/view/components/stats/main.tsx
@@ -49,7 +49,6 @@ class Main extends React.Component<{ intl: any, derived?: rivalScoreData[] } & R
 
   async updateScoreData(targetLevel = 12) {
     const bpi = new bpiCalcuator();
-    console.log(targetLevel);
     let exec = await (await new statMain(targetLevel).load(this.props.derived)).setLastData(String(Number(_currentStore()) - 1));
     const t = await new _totalBPI(targetLevel).load(true);
     const totalBPI = await t.currentVersion();

--- a/src/view/pages/data.tsx
+++ b/src/view/pages/data.tsx
@@ -80,7 +80,7 @@ class Index extends React.Component<P & RouteComponentProps, {
     if (user) {
       const bpi = new bpiCalcuator();
       const exec = await new statMain(12).load();
-      const totalBPI = bpi.setSongs(exec.at(), exec.at().length);
+      const totalBPI = await bpi.setSongs(exec.at());
       this.setState({
         uid: user.uid || user.photoURL,
         noName: !user.uid,
@@ -208,7 +208,7 @@ class Index extends React.Component<P & RouteComponentProps, {
 
       const bpi = new bpiCalcuator();
       const statsAPI = await new statMain(12).load();
-      const totalBPI = bpi.setSongs(statsAPI.at(), statsAPI.at().length);
+      const totalBPI = await bpi.setSongs(statsAPI.at());
       const lastDay = await statsAPI.eachDaySum(4, dayjs().subtract(1, 'day').format());
       const lastWeek = await statsAPI.eachDaySum(4, dayjs().subtract(1, 'week').format());
       const rank = bpi.rank(totalBPI, false);

--- a/src/view/pages/index.tsx
+++ b/src/view/pages/index.tsx
@@ -62,7 +62,7 @@ class Index extends React.Component<{ global: any } & RouteComponentProps, {
   async componentDidMount() {
     const bpi = new bpiCalcuator();
     let exec = await new statMain(12).load();
-    const totalBPI = bpi.setSongs(exec.at(), exec.at().length) || -15;
+    const totalBPI = await bpi.setSongs(exec.at()) || -15;
     let shift = await new scoresDB().getAll();
     shift = shift.filter((data: scoreData) => isSameWeek(data.updatedAt, new Date()));
     const _named = await named(12);
@@ -427,7 +427,7 @@ class RecentUsers extends React.Component<{ history: any }, { loading: boolean, 
   getRecentUsers = async () => {
     const fbA = new fbActions();
     fbA.auth().onAuthStateChanged(async (user: any) => {
-      const total = (await new totalBPI().load()).currentVersion();
+      const total = await (await new totalBPI().load()).currentVersion();
       const gt = total > 60 ? 50 : total - 2;
       const lt = total > 50 ? 100 : total + 5;
       const res = (await _apiFetch("users/getRecommend", { gt: gt, lt: lt }));


### PR DESCRIPTION
総合BPIの算出に根本的な間違いが存在したものを修正する。
BPI を算出するクラスに破壊的変更を行ったため、下記につき、ちゃんとテストを行ってからマージする

### 前提
- n=☆12の曲数
- k=累乗係数=log\[2\](n)
- BPI_1,BPI_2,BPI_3....BPI_n:☆12の各曲の単曲BPI
- 総合BPI = Σ(a=1→n)(BPIa^k/n)^(1/k) とする
- 上記式は [norimiso 様HP記載の原義](http://norimiso.web.fc2.com/aboutBPI.html) に基づくものとする

### 問題点
- 上記前提において、n=プレイ済み☆12の楽曲数となっており、☆12の楽曲総数を反映していなかった
- 統計画面においては☆11の総合BPIも算出可能だが、ここにおいて☆11を選択しても n=☆12の曲数 のままで、☆11の曲数を反映していなかった。

### 正しい実装
- n=☆11 または ☆12 の楽曲総数とする。https://github.com/BPIManager/BPIManager-Core/commit/4aeeab7b3727cb8b695515646f086e720c159241 において修正済み。
- a=1→n とすると、未プレイ楽曲はBPI = -15としてパディングすべきである。https://github.com/BPIManager/BPIManager-Core/pull/5/commits/0c2e25191241431637de49d77137398fafffe54a にておいて修正済み。  
現在の実装は、 i = プレイ済み楽曲数としたとき、Σ(a=1→i)(BPIa^k/n)^(1/k)としており、誤った実装である。

### 備考
- 上記において、 n = 楽曲総数 の算出条件は、下記に統一するものとする。
1. 12段階表記の難易度において、指定難易度と同一である。
2. BPI 算出非対応楽曲は n に含めないものとする。( WR 登録の有無により判別する )
3. AC 最新版より削除済みの楽曲は n に含めないものとする。( removed フラグにより判別する )
4. SP/DP の区別を行うものとする。