### PR TITLE
ステータスバーの色をヘッダーに合わせる

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BPIManager",
   "short_name": "BPIM",
-  "theme_color": "#3a3a3a",
+  "theme_color": "#d8ccbe",
   "background_color": "#260606",
   "display": "standalone",
   "scope": "/",


### PR DESCRIPTION
# 変更点
`menifest.json` で指定されている `theme_color` をヘッダーと同じ色に設定しました。
iPhone 14 Pro (iOS 17), Galaxy A20 (Android 11) にて動作確認済みです。

# スクリーンショット
![IMG_3032](https://github.com/BPIManager/BPIManager-Core/assets/7878530/41d46a2d-4874-493f-9db6-d1553f555fdd)
