### PR TITLE
iOSで正常にスコアが入力できないバグの修正

### DIFF
--- a/src/view/components/songs/detailScreen/scoreEditor.tsx
+++ b/src/view/components/songs/detailScreen/scoreEditor.tsx
@@ -42,6 +42,10 @@ const ScoreEditor: React.FC<{
             onKeyPress={(e) => {
               if (e.key === "Enter") e.preventDefault();
             }}
+            inputProps={{
+              pattern: "[0-9]*",
+              inputMode: "numeric"
+            }}
           />
         </form>
       </Grid>


### PR DESCRIPTION
# 概要
iOS Safariにてスコア編集機能が正常に入力できない問題の修正です
iOS15, 16, 17にて不具合確認済みです

# 既存不具合について
スコア入力した際、1->2のように複数続けて入力するとアプリとiOSのTextFieldの同期がうまく取れず
本来「12」と表示したいところ値が連結されて「112」と表示されてしまう
内部のcurrentScoreは正常に機能していることを確認済みで、あくまでiOSとMUIの相性のようです

https://github.com/BPIManager/BPIManager-Core/assets/14173984/2587804e-cef7-4030-bbbb-ecc4d802c90c

# 改修内容
* `inputProps`に数字の`pattern`を入れ予期しない文字を防ぐ
* `inputProps`の`inputMode`にnumericを指定し数値のみのキーボードにする
* 上記を指定し適切なキーボードを明示して正しく同期されるようにする

# テスト、確認項目
https://github.com/BPIManager/BPIManager-Core/assets/14173984/8d31a374-82bf-4fe3-acd5-c1e6143a0eaa
* 入力済みスコア、未プレイ共に正しく入力できること
iOS15, 16, 17とSafariでそれぞれ確認済みです
* PCにてデグレが存在しないこと
macOS14とChromeにて確認済みです