### PR TITLE
BPIにNaNが含まれる場合の統計画面推移タブの修正

### DIFF
--- a/src/components/bpi/index.tsx
+++ b/src/components/bpi/index.tsx
@@ -34,7 +34,7 @@ export default class bpiCalculator {
   }
 
   setBPIs(arr: number[]): this {
-    this._allTwelvesBPI = arr;
+    this._allTwelvesBPI = arr.filter(e=>!Number.isNaN(e));
     return this;
   }
 

--- a/src/components/stats/main.tsx
+++ b/src/components/stats/main.tsx
@@ -227,7 +227,7 @@ export default class statMain {
         }, []);
 
         const shift = this.getBPIShifts(this.eachDayShift[item]);
-        const BPIsArray = getBPIArray(allDiffs[item]);
+        const BPIsArray = getBPIArray(allDiffs[item]).filter(e=>!Number.isNaN(e));
         eachDaySum.push({
           name: item,
           sum: allDiffs[item].length,


### PR DESCRIPTION
## 概要
BPIにNaNが含まれる場合に統計画面推移タブの表示に異常がある問題の修正です。

- プライマリグラフの上限BPI、下限BPIが表示されない。
![localhost_3000_stats (4)](https://github.com/user-attachments/assets/6133422e-b0fc-42be-bfa6-03d2fb6a2960)
- 総合BPI推移でNaNが含まれた日以降の推移が表示されない。
![localhost_3000_stats (3)](https://github.com/user-attachments/assets/052cd31f-ca39-42bb-bc9b-04e7868551bb)

## 修正点
- プライマリグラフの上限BPI、下限BPIの計算元データである`BPIsArray`の取得時にNaN判定のフィルタを追加。
![localhost_3000_stats (5)](https://github.com/user-attachments/assets/169182be-aab6-4a88-8a83-faea8d70a28a)
- クラス`bpiCalculator`の`setBPIs()`にNaN判定のフィルタを追加。
![localhost_3000_stats (6)](https://github.com/user-attachments/assets/f8d0689b-abea-4813-9f31-e202a0a7aeab)

## 課題
総合BPIの計算箇所に修正を加えています。この修正でBPI NaNは-15として計算されます。
https://github.com/BPIManager/BPIManager-Core/pull/5#issue-1166483762 に於いて計算エラーがあったBPIの扱いが定められておりません。

NaNの発生原因が定義データ起因であれば、BPI算出対象として扱わずに総楽曲数nを-1するべきと思います。
プレーヤーの入力したデータ起因であれば、-15として扱っても良いと思います。

しかし、NaNの発生原因をハンドリングするような仕組みが無いので現実的には-15で統一せざるを得ないと思います。
